### PR TITLE
pq support + more tests + more

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,0 +1,74 @@
+package cache
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestMemoryCacheGet(t *testing.T) {
+	cache := NewMemoryCache(10)
+
+	// Test case 1: Get an existing item from the cache
+	cache.Set("key1", "content1", 10)
+	content, found := cache.Get("key1")
+	if !found {
+		t.Errorf("Expected item to be found in cache")
+	}
+	if string(content) != "content1" {
+		t.Errorf("Expected content to be 'content1', got '%s'", string(content))
+	}
+
+	// Test case 2: Get a non-existing item from the cache
+	_, found = cache.Get("non_existing_key")
+	if found {
+		t.Errorf("Expected item to not be found in cache")
+	}
+}
+
+func TestMemoryCacheSet(t *testing.T) {
+	cache := NewMemoryCache(5)
+
+	// Test case 1: Set an item with a positive duration
+	err := cache.Set("key1", "content1", 10)
+	if err != nil {
+		t.Errorf("Expected no error, got '%s'", err.Error())
+	}
+
+	// Test case 2: Set an item with a negative duration (never expires)
+	err = cache.Set("key2", "content2", -1)
+	if err != nil {
+		t.Errorf("Expected no error, got '%s'", err.Error())
+	}
+
+	for i := 3; i < 10; i++ {
+		cache.Set(fmt.Sprintf("key%v", i), "content", 10)
+	}
+
+	// Test case 3: Cache is full, remove the oldest item
+	_, found := cache.Get("key3")
+	if found {
+		t.Errorf("Expected item to be removed from cache")
+	}
+
+	// Test case 4: Validate the indefinite expiration time exists in the cache
+	_, found = cache.Get("key2")
+	if !found {
+		t.Errorf("Expected item to be found in cache")
+	}
+}
+
+func TestMakeCacheKey(t *testing.T) {
+	// Test case 1: Generate cache key with only required arguments
+	key := MakeCacheKey("graphID1", "variantID1", "operationName1")
+	expectedKey := "graphID1:variantID1:operationName1"
+	if key != expectedKey {
+		t.Errorf("Expected key to be '%s', got '%s'", expectedKey, key)
+	}
+
+	// Test case 2: Generate cache key with extra arguments
+	key = MakeCacheKey("graphID2", "variantID2", "operationName2", 123, true)
+	expectedKey = "graphID2:variantID2:operationName2:6a203127b0128340878b0beadbb7cabae0ad8ae6ff0f48a054cda7cdaa87f9d5"
+	if key != expectedKey {
+		t.Errorf("Expected key to be '%s', got '%s'", expectedKey, key)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"reflect"
 
@@ -23,8 +24,9 @@ type Config struct {
 
 // RelayConfig defines the address the proxy server listens on.
 type RelayConfig struct {
-	Address string         `yaml:"address"` // Address to bind the relay server on.
-	TLS     RelayTlsConfig `yaml:"tls"`     // TLS configuration for the relay server.
+	Address   string         `yaml:"address"`   // Address to bind the relay server on.
+	TLS       RelayTlsConfig `yaml:"tls"`       // TLS configuration for the relay server.
+	PublicURL string         `yaml:"publicURL"` // Public URL for the relay server.
 }
 
 // RelayTlsConfig defines the TLS configuration for the relay server.
@@ -88,6 +90,7 @@ func NewDefaultConfig() *Config {
 			RetryCount: -1,
 		},
 		Cache: CacheConfig{
+			Enabled:  true,
 			Duration: -1,
 			MaxSize:  1000,
 		},
@@ -226,6 +229,12 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("relay address cannot be empty")
 	}
 
+	if c.Relay.PublicURL != "" {
+		_, err := url.Parse(c.Relay.PublicURL)
+		if err != nil {
+			return fmt.Errorf("invalid publicURL: %s", err)
+		}
+	}
 	// Validate Uplink configuration
 	if len(c.Uplink.URLs) == 0 {
 		return fmt.Errorf("uplink URLs cannot be empty")

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -9,7 +9,9 @@ import (
 func MakeLogger(enableDebug *bool) *slog.Logger {
 	lvl := new(slog.LevelVar)
 
-	if *enableDebug {
+	if enableDebug == nil {
+		lvl.Set(slog.LevelInfo)
+	} else if *enableDebug {
 		lvl.Set(slog.LevelDebug)
 	} else {
 		lvl.Set(slog.LevelInfo)

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,0 +1,35 @@
+package logger
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+)
+
+func TestMakeLogger(t *testing.T) {
+	// Test case 1: Enable debug mode
+	enableDebug := true
+	logger := MakeLogger(&enableDebug)
+	if logger == nil {
+		t.Error("Expected logger instance, got nil")
+	}
+	if !logger.Enabled(context.Background(), slog.LevelDebug) {
+		t.Error("Expected logger level to be LevelDebug")
+	}
+
+	// Test case 2: Disable debug mode
+	enableDebug = false
+	logger = MakeLogger(&enableDebug)
+	if logger == nil {
+		t.Error("Expected logger instance, got nil")
+	}
+	if !logger.Enabled(context.Background(), slog.LevelInfo) {
+		t.Error("Expected logger level to be LevelInfo")
+	}
+
+	// Test case 3: Passing a nil value
+	logger = MakeLogger(nil)
+	if logger == nil {
+		t.Error("Expected logger instance, got nil")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"apollosolutions/uplink-relay/cache"
 	"apollosolutions/uplink-relay/config"
 	"apollosolutions/uplink-relay/logger"
+	persistedqueries "apollosolutions/uplink-relay/persisted_queries"
 	"apollosolutions/uplink-relay/polling"
 	"apollosolutions/uplink-relay/proxy"
 	apolloredis "apollosolutions/uplink-relay/redis"
@@ -81,7 +82,7 @@ func main() {
 
 	// Set up the main request handler
 	proxy.RegisterHandlers("/*", proxy.RelayHandler(mergedConfig, uplinkCache, rrSelector, httpClient, logger))
-
+	proxy.RegisterHandlers("/persisted-queries/*", persistedqueries.PersistedQueryHandler(logger, httpClient, uplinkCache))
 	// Set up the webhook handler if enabled
 	if mergedConfig.Webhook.Enabled {
 		proxy.RegisterHandlers(mergedConfig.Webhook.Path, webhooks.WebhookHandler(mergedConfig, uplinkCache, httpClient, logger))

--- a/persisted_queries/persisted_queries.go
+++ b/persisted_queries/persisted_queries.go
@@ -1,0 +1,142 @@
+package persistedqueries
+
+import (
+	"apollosolutions/uplink-relay/cache"
+	"apollosolutions/uplink-relay/config"
+	"bytes"
+	"compress/zlib"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type UplinkPersistedQueryResponse struct {
+	Data struct {
+		PersistedQueries UplinkPersistedQueryPersistedQueries `json:"persistedQueries"`
+	} `json:"data"`
+}
+
+type UplinkPersistedQueryPersistedQueries struct {
+	ID              string                      `json:"id"`
+	Typename        string                      `json:"__typename"`
+	MinDelaySeconds float64                     `json:"minDelaySeconds"`
+	Chunks          []UplinkPersistedQueryChunk `json:"chunks,omitempty"`
+}
+
+type UplinkPersistedQueryChunk struct {
+	ID   string   `json:"id"`
+	URLs []string `json:"urls"`
+}
+
+/*
+*
+
+	The path follows the format of /persisted-queries/{id}?i={index} where {id} is the unique identifier of the persisted query, and {index} is the index of the chunk.
+	For example, /persisted-queries/123/0 would represent the first chunk of the persisted query with ID 123.
+
+*
+*/
+const pathPrefix = "/persisted-queries/"
+
+func PersistedQueryHandler(logger *slog.Logger, client *http.Client, systemCache cache.Cache) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		logger.Debug("Received request", "path", r.URL.Path)
+		id := strings.Split(r.URL.Path, pathPrefix)[1]
+		if id == "" {
+			w.Header().Set("Content-Type", "application/json")
+			http.Error(w, `{"error":"Invalid path format"}`, http.StatusBadRequest)
+			return
+		}
+		logger.Debug("Received request for chunk", "path", id)
+
+		index := r.URL.Query().Get("i")
+		if index == "" {
+			w.Header().Set("Content-Type", "application/json")
+			http.Error(w, `{"error":"Invalid path format"}`, http.StatusBadRequest)
+			return
+		}
+
+		logger.Debug("Received request", "id", id, "index", index)
+		content, ok := systemCache.Get(makePersistedQueryCacheKey(id, index))
+		if !ok {
+			// Handle cache miss error
+			w.Header().Set("Content-Type", "application/json")
+			http.Error(w, `{"error":"Manifest not found"}`, http.StatusNotFound)
+			return
+		}
+
+		// Write the content to the response
+		reader, err := zlib.NewReader(bytes.NewReader(content))
+		if err != nil {
+			http.Error(w, "Error reading content", http.StatusInternalServerError)
+			return
+		}
+		defer reader.Close()
+		io.Copy(w, reader)
+	}
+}
+
+func CachePersistedQueryChunkData(config *config.Config, logger *slog.Logger, systemCache cache.Cache, chunks []UplinkPersistedQueryChunk) ([]UplinkPersistedQueryChunk, error) {
+	// Validate caching is disabled, but also ignore this logic altogether if there's no public URL in the config, as it's used to advertise the cached URLs.
+	if !config.Cache.Enabled || config.Relay.PublicURL == "" {
+		logger.Debug("Caching disabled, skipping", "publicURL", config.Relay.PublicURL, "cacheEnabled", config.Cache.Enabled)
+		return chunks, nil
+	}
+	parsedUrl, err := url.Parse(config.Relay.PublicURL)
+	if err != nil {
+		return nil, err
+	}
+	for c, chunk := range chunks {
+		newUrls := []string{}
+		for u, chunkUrl := range chunk.URLs {
+			cacheKey := makePersistedQueryCacheKey(chunk.ID, strconv.Itoa(u))
+
+			// Fetch the content from the uplink.
+			res, err := http.Get(chunkUrl)
+			if err != nil {
+				return nil, err
+			}
+			body, err := io.ReadAll(res.Body)
+			if err != nil {
+				return nil, err
+			}
+
+			// compress the text for reducing overall size of the cache entry
+			var b bytes.Buffer
+			w := zlib.NewWriter(&b)
+			_, err = w.Write(body)
+			if err != nil {
+				return nil, err
+			}
+			w.Close()
+
+			// Set the content in the cache.
+			if err := systemCache.Set(cacheKey, string(b.String()), config.Cache.Duration); err != nil {
+				return nil, err
+			}
+
+			protocol := parsedUrl.Scheme
+			if config.Relay.TLS.KeyFile != "" || config.Relay.TLS.CertFile != "" {
+				protocol = "https"
+			}
+			parsedUrl.Scheme = protocol
+			parsedUrl = parsedUrl.JoinPath(pathPrefix)
+			logger.Debug("Cached persisted query chunk", "id", chunk.ID, "urls", chunk.URLs, "chunks", chunks, "parsedUrl", parsedUrl.String())
+			// Update the URL to point to the local server.
+			newUrls = append(newUrls, fmt.Sprintf("%s%s?i=%d", parsedUrl.String(), chunk.ID, u))
+		}
+		// Update the chunk URLs to point to the local server.
+		chunks[c].URLs = newUrls
+		logger.Debug("Cached persisted query chunk", "id", chunk.ID, "urls", newUrls, "chunks", chunks)
+
+	}
+	return chunks, nil
+}
+
+func makePersistedQueryCacheKey(id string, index string) string {
+	return fmt.Sprintf("pq:%s:%s", id, index)
+}

--- a/persisted_queries/persisted_queries_test.go
+++ b/persisted_queries/persisted_queries_test.go
@@ -1,0 +1,196 @@
+package persistedqueries
+
+import (
+	"apollosolutions/uplink-relay/cache"
+	"apollosolutions/uplink-relay/config"
+	"apollosolutions/uplink-relay/logger"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestPersistedQueryHandler(t *testing.T) {
+	pT := true
+	log := logger.MakeLogger(&pT)
+	mockCache := cache.NewMemoryCache(1000)
+	mockConfig := config.NewDefaultConfig()
+	mockConfig.Relay.PublicURL = "http://example.com/"
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"data":{"persistedQueries":{"id":"123","__typename":"","minDelaySeconds":0,"chunks":null}}}`))
+	}))
+	// Prefill cache with test data
+	_, err := CachePersistedQueryChunkData(mockConfig, log, mockCache, []UplinkPersistedQueryChunk{{
+		ID:   "123",
+		URLs: []string{mockServer.URL},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test case 1: Valid request with existing persisted query
+	req1, err := http.NewRequest("GET", "/persisted-queries/123?i=0", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr1 := httptest.NewRecorder()
+	handler1 := http.HandlerFunc(PersistedQueryHandler(log, http.DefaultClient, mockCache))
+	handler1.ServeHTTP(rr1, req1)
+	if status := rr1.Code; status != http.StatusOK {
+		t.Errorf("Handler returned wrong status code: got %v, want %v", status, http.StatusOK)
+	}
+	expectedResponse1 := `{"data":{"persistedQueries":{"id":"123","__typename":"","minDelaySeconds":0,"chunks":null}}}`
+	if rr1.Body.String() != expectedResponse1 {
+		t.Errorf("Handler returned unexpected body: got %v, want %v", rr1.Body.String(), expectedResponse1)
+	}
+
+	// Test case 2: Invalid request with non-existent persisted query
+	req2, err := http.NewRequest("GET", "/persisted-queries/456?i=0", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr2 := httptest.NewRecorder()
+	handler2 := http.HandlerFunc(PersistedQueryHandler(log, http.DefaultClient, mockCache))
+	handler2.ServeHTTP(rr2, req2)
+	if status := rr2.Code; status != http.StatusNotFound {
+		t.Errorf("Handler returned wrong status code: got %v, want %v", status, http.StatusNotFound)
+	}
+	expectedResponse2 := `{"error":"Manifest not found"}`
+	if strings.TrimSpace(rr2.Body.String()) != expectedResponse2 {
+		t.Errorf("Handler returned unexpected body: got %v, want %v", rr2.Body.String(), expectedResponse2)
+	}
+
+	// Test case 3: Invalid request with incorrect path format
+	req3, err := http.NewRequest("GET", "/persisted-queries/789", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr3 := httptest.NewRecorder()
+	handler3 := http.HandlerFunc(PersistedQueryHandler(log, http.DefaultClient, mockCache))
+	handler3.ServeHTTP(rr3, req3)
+	if status := rr3.Code; status != http.StatusBadRequest {
+		t.Errorf("Handler returned wrong status code: got %v, want %v", status, http.StatusBadRequest)
+	}
+	expectedResponse3 := `{"error":"Invalid path format"}`
+	if strings.TrimSpace(rr3.Body.String()) != expectedResponse3 {
+		t.Errorf("Handler returned unexpected body: got %v, want %v", rr3.Body.String(), expectedResponse3)
+	}
+
+	// Test case 4: check if the publicURL has an existing path (e.g. example.com/pq/) whether that'll also work
+	mockConfig.Relay.PublicURL = "http://example.com/pq/"
+	// Prefill cache with test data
+	_, err = CachePersistedQueryChunkData(mockConfig, log, mockCache, []UplinkPersistedQueryChunk{{
+		ID:   "123",
+		URLs: []string{mockServer.URL},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req4, err := http.NewRequest("GET", "/pq/persisted-queries/123?i=0", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr4 := httptest.NewRecorder()
+	handler4 := http.HandlerFunc(PersistedQueryHandler(log, http.DefaultClient, mockCache))
+	handler4.ServeHTTP(rr4, req4)
+	if status := rr4.Code; status != http.StatusOK {
+		t.Errorf("Handler returned wrong status code: got %v, want %v", status, http.StatusOK)
+	}
+
+	// Test case 5: check if the cache is skipped when the publicURL is empty
+	mockConfig.Relay.PublicURL = ""
+	// Reset cache
+	mockCache = cache.NewMemoryCache(1000)
+	// Attempt to prefill cache with test data
+	_, err = CachePersistedQueryChunkData(mockConfig, log, mockCache, []UplinkPersistedQueryChunk{{
+		ID:   "123",
+		URLs: []string{mockServer.URL},
+	}})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req5, err := http.NewRequest("GET", "/persisted-queries/123?i=0", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr5 := httptest.NewRecorder()
+	handler5 := http.HandlerFunc(PersistedQueryHandler(log, http.DefaultClient, mockCache))
+	handler5.ServeHTTP(rr5, req5)
+	if status := rr5.Code; status != http.StatusNotFound {
+		t.Errorf("Handler returned wrong status code: got %v, want %v", status, http.StatusNotFound)
+	}
+	_, found := mockCache.Get("pq:123:0")
+	if found {
+		t.Errorf("Expected item to not be found in cache")
+	}
+}
+
+func TestCachePersistedQueryChunkData(t *testing.T) {
+	log := logger.MakeLogger(nil)
+	mockCache := cache.NewMemoryCache(1000)
+	mockConfig := config.NewDefaultConfig()
+	mockConfig.Relay.PublicURL = "example.com"
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"format":"apollo-persisted-query-manifest","version":1,"operations":[{"id":"1234","body":"query{__typename}"}]}`))
+	}))
+	// Test case 1: Cache persisted query chunk data successfully
+	chunks := []UplinkPersistedQueryChunk{{
+		ID:   "456",
+		URLs: []string{mockServer.URL},
+	}}
+	cachedChunks, err := CachePersistedQueryChunkData(mockConfig, log, mockCache, chunks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cachedChunks) != len(chunks) {
+		t.Errorf("Cached chunks length mismatch: got %v, want %v", len(cachedChunks), len(chunks))
+	}
+	for i, chunk := range cachedChunks {
+		if chunk.ID != chunks[i].ID {
+			t.Errorf("Cached chunk ID mismatch: got %v, want %v", chunk.ID, chunks[i].ID)
+		}
+		if len(chunk.URLs) != len(chunks[i].URLs) {
+			t.Errorf("Cached chunk URLs length mismatch: got %v, want %v", len(chunk.URLs), len(chunks[i].URLs))
+		}
+		for j, url := range chunk.URLs {
+			if url != chunks[i].URLs[j] {
+				t.Errorf("Cached chunk URL mismatch: got %v, want %v", url, chunks[i].URLs[j])
+			}
+		}
+	}
+
+}
+
+func TestMakePersistedQueryCacheKey(t *testing.T) {
+	// Test case 1: Valid input
+	id := "123"
+	index := "0"
+	expectedKey := "pq:123:0"
+	result := makePersistedQueryCacheKey(id, index)
+	if result != expectedKey {
+		t.Errorf("Unexpected cache key: got %v, want %v", result, expectedKey)
+	}
+
+	// Test case 2: Empty input
+	id = ""
+	index = ""
+	expectedKey = "pq::"
+	result = makePersistedQueryCacheKey(id, index)
+	if result != expectedKey {
+		t.Errorf("Unexpected cache key: got %v, want %v", result, expectedKey)
+	}
+
+	// Test case 3: Input with special characters
+	id = "abc!@#$%^&*()"
+	index = "1"
+	expectedKey = "pq:abc!@#$%^&*():1"
+	result = makePersistedQueryCacheKey(id, index)
+	if result != expectedKey {
+		t.Errorf("Unexpected cache key: got %v, want %v", result, expectedKey)
+	}
+
+}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -12,15 +12,27 @@ import (
 	"apollosolutions/uplink-relay/uplink"
 )
 
+const supergraphQuery = `{"query":"query SupergraphSdlQuery($apiKey: String!, $graph_ref: String!, $ifAfterId: ID) {\n    routerConfig(ref: $graph_ref, apiKey: $apiKey, ifAfterId: $ifAfterId) {\n            __typename\n            ... on RouterConfigResult {\n                    id\n                    supergraphSdl: supergraphSDL\n                    minDelaySeconds\n            }\n            ... on Unchanged {\n                    id\n                    minDelaySeconds\n            }\n            ... on FetchError {\n                    code\n                    message\n            }\n    }\n}","operationName":"SupergraphSdlQuery","variables":{"apiKey":"service:graph:1234","graph_ref":"pq-graph@local","ifAfterId":null}}`
+const supergraphResponse = `{"data":{"routerConfig":{"__typename":"RouterConfigResult","id":"2024-02-09T19:34:43.322688000Z","supergraphSdl":"mock supergraph sdl","minDelaySeconds":30}}}`
+
 const licenseQuery = `{"variables":{"apiKey":"service:graph:1234","graph_ref":"graph@local","ifAfterId":null},"query":"query LicenseQuery($apiKey: String!, $graph_ref: String!, $ifAfterId: ID) {\n\n    routerEntitlements(ifAfterId: $ifAfterId, apiKey: $apiKey, ref: $graph_ref) {\n        __typename\n        ... on RouterEntitlementsResult {\n            id\n            minDelaySeconds\n            entitlement {\n                jwt\n            }\n        }\n        ... on Unchanged {\n            id\n            minDelaySeconds\n        }\n        ... on FetchError {\n            code\n            message\n        }\n    }\n}\n","operationName":"LicenseQuery"}`
 const licenseResponse = `{"data":{"routerEntitlements":{"__typename":"RouterEntitlementsResult","id":"2024-08-02T12:00:00Z","minDelaySeconds":60.0,"entitlement":{"jwt":"bob"}}}}`
+
+const persistedQueriesQuery = `{"query":"query PersistedQueriesManifestQuery(\n    $apiKey: String!\n    $graph_ref: String!\n    $ifAfterId: ID\n) {\n    persistedQueries(ref: $graph_ref, apiKey: $apiKey, ifAfterId: $ifAfterId) {\n        __typename\n        ... on PersistedQueriesResult {\n            id\n            minDelaySeconds\n            chunks {\n                id\n                urls\n            }\n        }\n        ... on Unchanged {\n            id\n            minDelaySeconds\n        }\n        ... on FetchError {\n            code\n            message\n        }\n    }\n}\n","operationName":"PersistedQueriesManifestQuery","variables":{"apiKey":"service:graph:1234","graph_ref":"pq-graph@local","ifAfterId":null}}`
+const persistedQueriesResponse = `{"data":{"persistedQueries":{"id":"id1","__typename":"PersistedQueriesResult","minDelaySeconds":60,"chunks":[{"id":"graph/1234","urls":["https://apollographql.com"]}]}}}`
 
 func TestRelayHandler(t *testing.T) {
 	// Create a mock HTTP server for testing
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Mock the response from the uplink service
+		if r.URL.Path == "/s" {
+			w.Write([]byte(supergraphResponse))
+		} else if r.URL.Path == "/l" {
+			w.Write([]byte(licenseResponse))
+		} else if r.URL.Path == "/pq" {
+			w.Write([]byte(persistedQueriesResponse))
+		}
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(licenseResponse))
 	}))
 	defer mockServer.Close()
 
@@ -38,9 +50,6 @@ func TestRelayHandler(t *testing.T) {
 		},
 	}
 
-	// Create a mock round-robin selector
-	mockRRSelector := uplink.NewRoundRobinSelector([]string{mockServer.URL})
-
 	// Create a mock HTTP client
 	mockHTTPClient := &http.Client{}
 
@@ -49,14 +58,16 @@ func TestRelayHandler(t *testing.T) {
 	mockLogger := logger.MakeLogger(&pFalse)
 
 	// Create a new test request
-	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(licenseQuery))
+	req := httptest.NewRequest(http.MethodPost, "/l", strings.NewReader(licenseQuery))
 
 	// Create a response recorder to capture the response
 	rr := httptest.NewRecorder()
 
 	// Call the RelayHandler function
+	mockRRSelector := uplink.NewRoundRobinSelector([]string{mockServer.URL + "/l"})
 	handler := RelayHandler(mockConfig, mockCache, mockRRSelector, mockHTTPClient, mockLogger)
 	handler.ServeHTTP(rr, req)
+
 	// Assert that the response status code is 200
 	if rr.Code != http.StatusOK {
 		t.Errorf("Expected status code 200, but got %d", rr.Code)
@@ -65,10 +76,8 @@ func TestRelayHandler(t *testing.T) {
 	if rr.Body.String() != licenseResponse {
 		t.Errorf("Expected response body '%s', but got '%s'", licenseResponse, rr.Body.String())
 	}
-	var key = cache.MakeCacheKey("graph", "local", "LicenseQuery")
-	if key != "graph:local:LicenseQuery" {
-		t.Errorf("Expected cache key 'graph:local:LicenseQuery', but got '%s'", key)
-	}
+	var key = cache.MakeCacheKey("graph", "local", "LicenseQuery", map[string]interface{}{"apiKey": "service:graph:1234", "graph_ref": "graph@local", "ifAfterId": nil})
+
 	// Assert that the response body is cached
 	if _, ok := mockCache.Get(key); !ok {
 		t.Errorf("Expected response body to be cached, but it was not")
@@ -82,6 +91,46 @@ func TestRelayHandler(t *testing.T) {
 		t.Errorf("Expected status code 400, but got %d", rr.Code)
 	}
 
+	/**
+	 * Test the SupergraphSdlQuery
+	**/
+	// Create a new test request
+	req = httptest.NewRequest(http.MethodPost, "/s", strings.NewReader(supergraphQuery))
+
+	// Create a response recorder to capture the response
+	rr = httptest.NewRecorder()
+	mockRRSelector = uplink.NewRoundRobinSelector([]string{mockServer.URL + "/s"})
+	handler = RelayHandler(mockConfig, mockCache, mockRRSelector, mockHTTPClient, mockLogger)
+	handler.ServeHTTP(rr, req)
+
+	// Assert that the response status code is 200
+	if rr.Code != http.StatusOK {
+		t.Errorf("Expected status code 200, but got %d", rr.Code)
+	}
+	// Assert that the response body matches the expected value
+	if rr.Body.String() != supergraphResponse {
+		t.Errorf("Expected response body '%s', but got '%s'", supergraphResponse, rr.Body.String())
+	}
+
+	/**
+	 * Test the PersistedQueriesManifestQuery
+	**/
+	// Create a new test request
+	req = httptest.NewRequest(http.MethodPost, "/pq", strings.NewReader(persistedQueriesQuery))
+
+	// Create a response recorder to capture the response
+	rr = httptest.NewRecorder()
+	mockRRSelector = uplink.NewRoundRobinSelector([]string{mockServer.URL + "/pq"})
+	handler = RelayHandler(mockConfig, mockCache, mockRRSelector, mockHTTPClient, mockLogger)
+	handler.ServeHTTP(rr, req)
+	// Assert that the response status code is 200
+	if rr.Code != http.StatusOK {
+		t.Errorf("Expected status code 200, but got %d", rr.Code)
+	}
+	// Assert that the response body matches the expected value
+	if rr.Body.String() != persistedQueriesResponse {
+		t.Errorf("Expected response body '%s', but got '%s'", persistedQueriesResponse, rr.Body.String())
+	}
 }
 
 func TestHandleCacheHit(t *testing.T) {
@@ -106,12 +155,33 @@ func TestHandleCacheHit(t *testing.T) {
 		t.Errorf("Expected status code 200, but got %d", rr.Code)
 	}
 
-	// Recreate the test request with a nil body
+	// Reset test request and response recorder
+	rr = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPost, "/", nil)
 
 	// Call the handleCacheHit again for the SupergraphQuery
 	err = handleCacheHit(cache.MakeCacheKey("graph", "local", "SupergraphSdlQuery"), []byte("1234"), mockLogger)(rr, req)
 	if err != nil {
 		t.Errorf("Expected no error, but got %v", err)
+	}
+
+	// Assert that the response status code is 200
+	if rr.Code != http.StatusOK {
+		t.Errorf("Expected status code 200, but got %d", rr.Code)
+	}
+
+	// Reset test request and response recorder
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/", nil)
+
+	// Call the handleCacheHit again for the PersistedQueriesManifestQuery
+	err = handleCacheHit(cache.MakeCacheKey("graph", "local", "PersistedQueriesManifestQuery"), []byte(persistedQueriesResponse), mockLogger)(rr, req)
+	if err != nil {
+		t.Errorf("Expected no error, but got %v", err)
+	}
+
+	// Assert that the response status code is 200
+	if rr.Code != http.StatusOK {
+		t.Errorf("Expected status code 200, but got %d", rr.Code)
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,7 @@ Uplink Relay can be configured using a YAML configuration file. Here's a complet
 ```yaml
 relay:
   address: "localhost:8080"
+  publicURL: "localhost:8080"
 uplink:
   timeout: 10
   urls:


### PR DESCRIPTION
This one is a little meatier than expected, but covers three big areas: 

- First, it adds support for [Persisted Queries](https://www.apollographql.com/docs/graphos/operations/persisted-queries/)
- Next, it adds support for proper support for `Unchanged` caches through some modifications to the cache key calculation
- Lastly, more tests

## Persisted Queries

This one is relatively straightforward, but this adds support to cache Persisted Queries through the same mechanism as before. The only callout here is due to how the IDs are formatted for PQs, the entire response is currently being cached, although there is some functionality here that's important to note as well.

As the current PQ system returns a signed URL that expires in an hour, this _also_ adds support to store PQs in Redis. The PQ manifests are downloaded via Relay, and then uploaded into the cache compressed using `zlib` to avoid crushing the cache. 

This behavior may be something we want to support natively, but is outside of scope for this specific PR. 

## `Unchanged` support

The Uplink API will, given the `ifAfterId` parameter being passed, send back an `Unchanged` type to the requestor. This has  a side effect whereby a router would continuously see that it has a "new" schema to reload (or PQs), and have to calculate whether to update or not. 

By supporting `Unchanged`, we can mitigate that. 

This is done through updating the cache key calculation to accept an arbitrary number of arguments, and then sha256 hashing them as part of the end of the key. This is primarily used to insert the arguments as the remaining entries, meaning that the cache entry is unique per the specific `ifAfterId` _and_ the graphRef/apiKey, such that it shouldn't cause collisions further than that. 

## Tests

Called out by a few customers (and myself), this adds more tests to the repo and we have nearly all files with some level of testing. The config will eventually need testing, but feels safe enough as-is. Code coverage can certainly be improved, however.  