### PR TITLE
Hardening the application further

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -60,6 +60,9 @@ func (c *MemoryCache) Set(key string, content string, duration int) error {
 		var oldestExpiration time.Time
 		for k, v := range c.items {
 			if oldestKey == "" || timeBeforeWithIndefinite(v.Expiration, oldestExpiration) {
+				if isIndefinite(v.Expiration) {
+					continue
+				}
 				oldestKey = k
 				oldestExpiration = v.Expiration
 			}
@@ -91,5 +94,9 @@ func MakeCacheKey(graphID, variantID, operationName string, extraArgs ...interfa
 }
 
 func timeBeforeWithIndefinite(expirationTime time.Time, compareTo time.Time) bool {
-	return expirationTime.Before(compareTo) && expirationTime != time.Unix(1<<63-1, 0)
+	return expirationTime.Before(compareTo) && !isIndefinite(expirationTime)
+}
+
+func isIndefinite(expirationTime time.Time) bool {
+	return expirationTime == time.Unix(1<<63-1, 0)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"slices"
 
 	"gopkg.in/yaml.v3"
 )
@@ -230,10 +231,20 @@ func (c *Config) Validate() error {
 	}
 
 	if c.Relay.PublicURL != "" {
-		_, err := url.Parse(c.Relay.PublicURL)
+		allowedProtocols := []string{"http", "https"}
+		parsedUrl, err := url.Parse(c.Relay.PublicURL)
 		if err != nil {
 			return fmt.Errorf("invalid publicURL: %s", err)
 		}
+
+		if parsedUrl == nil || parsedUrl.Scheme == "" || parsedUrl.Host == "" {
+			return fmt.Errorf("invalid publicURL: %s", c.Relay.PublicURL)
+		}
+
+		if !slices.Contains(allowedProtocols, parsedUrl.Scheme) {
+			return fmt.Errorf(`invalid publicURL scheme "%s"; must be one of "http" or "https"`, parsedUrl.Scheme)
+		}
+
 	}
 	// Validate Uplink configuration
 	if len(c.Uplink.URLs) == 0 {

--- a/persisted_queries/persisted_queries.go
+++ b/persisted_queries/persisted_queries.go
@@ -86,6 +86,10 @@ func CachePersistedQueryChunkData(config *config.Config, logger *slog.Logger, sy
 		logger.Debug("Caching disabled, skipping", "publicURL", config.Relay.PublicURL, "cacheEnabled", config.Cache.Enabled)
 		return chunks, nil
 	}
+	if !strings.HasPrefix(config.Relay.PublicURL, "http") {
+		logger.Error("Invalid public URL", "publicURL", config.Relay.PublicURL)
+		return nil, fmt.Errorf("invalid publicURL: %s", config.Relay.PublicURL)
+	}
 	parsedUrl, err := url.Parse(config.Relay.PublicURL)
 	if err != nil {
 		return nil, err

--- a/persisted_queries/persisted_queries_test.go
+++ b/persisted_queries/persisted_queries_test.go
@@ -121,7 +121,7 @@ func TestPersistedQueryHandler(t *testing.T) {
 	handler5 := http.HandlerFunc(PersistedQueryHandler(log, http.DefaultClient, mockCache))
 	handler5.ServeHTTP(rr5, req5)
 	if status := rr5.Code; status != http.StatusNotFound {
-		t.Errorf("Handler returned wrong status code: got %v, want %v", status, http.StatusOK)
+		t.Errorf("Handler returned wrong status code: got %v, want %v", status, http.StatusNotFound)
 	}
 	_, found := mockCache.Get("pq:123:0")
 	if found {

--- a/persisted_queries/persisted_queries_test.go
+++ b/persisted_queries/persisted_queries_test.go
@@ -121,7 +121,7 @@ func TestPersistedQueryHandler(t *testing.T) {
 	handler5 := http.HandlerFunc(PersistedQueryHandler(log, http.DefaultClient, mockCache))
 	handler5.ServeHTTP(rr5, req5)
 	if status := rr5.Code; status != http.StatusNotFound {
-		t.Errorf("Handler returned wrong status code: got %v, want %v", status, http.StatusNotFound)
+		t.Errorf("Handler returned wrong status code: got %v, want %v", status, http.StatusOK)
 	}
 	_, found := mockCache.Get("pq:123:0")
 	if found {
@@ -133,7 +133,7 @@ func TestCachePersistedQueryChunkData(t *testing.T) {
 	log := logger.MakeLogger(nil)
 	mockCache := cache.NewMemoryCache(1000)
 	mockConfig := config.NewDefaultConfig()
-	mockConfig.Relay.PublicURL = "example.com"
+	mockConfig.Relay.PublicURL = "http://example.com"
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`{"format":"apollo-persisted-query-manifest","version":1,"operations":[{"id":"1234","body":"query{__typename}"}]}`))
 	}))
@@ -163,6 +163,17 @@ func TestCachePersistedQueryChunkData(t *testing.T) {
 		}
 	}
 
+	// Test case 2: Invalid URL causes an error
+	// Missing protocol
+	mockConfig.Relay.PublicURL = "example.com"
+	chunks = []UplinkPersistedQueryChunk{{
+		ID:   "789",
+		URLs: []string{mockServer.URL},
+	}}
+	_, err = CachePersistedQueryChunkData(mockConfig, log, mockCache, chunks)
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
 }
 
 func TestMakePersistedQueryCacheKey(t *testing.T) {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -227,7 +227,7 @@ func modifyProxiedResponse(config *config.Config, cache cache.Cache, cacheKey st
 		// Unmarshal the response body into the response struct
 		err := json.Unmarshal(responseBody, &responseStruct)
 		if err != nil {
-			logger.Error("Failed to unmarshal response body", "err", err, "responseBody", string(responseBody[:]), "operationName", uplinkRequest.OperationName, "cacheKey", cacheKey, "response headers", resp.Header)
+			logger.Error("Failed to unmarshal response body", "err", err, "responseBody", string(responseBody[:]))
 			return nil
 		}
 		// Cache the response based on the operation name

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ Uplink Relay can be configured using a YAML configuration file. Here's a complet
 ```yaml
 relay:
   address: "localhost:8080"
-  publicURL: "localhost:8080"
+  publicURL: "http://localhost:8080"
 uplink:
   timeout: 10
   urls:


### PR DESCRIPTION
This has a few fixes after running a small loadtest, but notably: 

* The persisted query endpoint when proxying will return with `gzip` encoding, so this adds a check for that and decompresses before sending to the response
* `publicURL` needs to be prefixed with a schema otherwise the logic to append the pathing doesn't work properly; the validation is done in the config at startup

Adds some minor testing updates as well. 