### PR TITLE
fix: round timestamp to improve cache hit

### DIFF
--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"apollosolutions/uplink-relay/cache"
 	"apollosolutions/uplink-relay/config"
@@ -137,7 +138,8 @@ func TestHandleCacheHit(t *testing.T) {
 	// Create a mock logger
 	pFalse := false
 	mockLogger := logger.MakeLogger(&pFalse)
-
+	mockConfig := config.NewDefaultConfig()
+	mockConfig.Cache.Duration = 10
 	// Create a new test request
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(licenseQuery))
 
@@ -145,7 +147,7 @@ func TestHandleCacheHit(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	// Call the handleCacheHit function
-	err := handleCacheHit(cache.MakeCacheKey("graph", "local", "LicenseQuery"), []byte(licenseResponse), mockLogger)(rr, req)
+	err := handleCacheHit(cache.MakeCacheKey("graph", "local", "LicenseQuery"), []byte(licenseResponse), mockLogger, time.Duration(mockConfig.Cache.Duration)*time.Second)(rr, req)
 	if err != nil {
 		t.Errorf("Expected no error, but got %v", err)
 	}
@@ -160,7 +162,7 @@ func TestHandleCacheHit(t *testing.T) {
 	req = httptest.NewRequest(http.MethodPost, "/", nil)
 
 	// Call the handleCacheHit again for the SupergraphQuery
-	err = handleCacheHit(cache.MakeCacheKey("graph", "local", "SupergraphSdlQuery"), []byte("1234"), mockLogger)(rr, req)
+	err = handleCacheHit(cache.MakeCacheKey("graph", "local", "SupergraphSdlQuery"), []byte("1234"), mockLogger, time.Duration(mockConfig.Cache.Duration)*time.Second)(rr, req)
 	if err != nil {
 		t.Errorf("Expected no error, but got %v", err)
 	}
@@ -175,7 +177,7 @@ func TestHandleCacheHit(t *testing.T) {
 	req = httptest.NewRequest(http.MethodPost, "/", nil)
 
 	// Call the handleCacheHit again for the PersistedQueriesManifestQuery
-	err = handleCacheHit(cache.MakeCacheKey("graph", "local", "PersistedQueriesManifestQuery"), []byte(persistedQueriesResponse), mockLogger)(rr, req)
+	err = handleCacheHit(cache.MakeCacheKey("graph", "local", "PersistedQueriesManifestQuery"), []byte(persistedQueriesResponse), mockLogger, time.Duration(mockConfig.Cache.Duration)*time.Second)(rr, req)
 	if err != nil {
 		t.Errorf("Expected no error, but got %v", err)
 	}


### PR DESCRIPTION
With the changes added in #2, we added the variables passed in the operation into the cache key calculation. 

This meant that for the router, it would use the timestamp for the `ifAfterId` provided by `uplink-relay`, which was the current timestamp for subsequent requests.

This led to a large number of cache misses, thus had the unfortunate side effect of mitigating the value of `uplink-relay` for use beyond initial startup. 

This PR rounds the timestamp to the cache duration- such that if a duration of 300 seconds (5 minutes), the timestamp would be shown as increments of 5 minutes (e.g. `2024-07-26 15:45:00 +0000 UTC`) rounded by Golang's [`Time.Round`](https://pkg.go.dev/time#Time.Round) function (details in link). 