### PR TITLE
feat: create docker image when a new tag is created to simplify container distribution

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -4,7 +4,8 @@ name: Build and Publish
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
   push:
-    branches: ['release']
+    tags:
+      - '*'
   workflow_dispatch:
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
@@ -22,7 +23,7 @@ jobs:
       contents: read
       packages: write
       attestations: write
-      # 
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -39,6 +40,9 @@ jobs:
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=ref,event=workflow_dispatch
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 # Start from the latest golang base image
-FROM golang:latest
-
-# Add Maintainer Info
-LABEL maintainer="Apollo GraphQL Solutions"
+FROM golang:1.22-bookworm as build
 
 # Set the Current Working Directory inside the container
 WORKDIR /app
@@ -17,10 +14,22 @@ RUN go mod download
 COPY . .
 
 # Build the Go app
-RUN go build .
+RUN go build -o /app/uplink-relay . 
+
+# Execution stage
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y ca-certificates
+
+USER 1001:1001
+
+COPY --from=build /app/uplink-relay /app/uplink-relay
+
+# Add Maintainer Info
+LABEL maintainer="Apollo GraphQL Solutions"
 
 # Expose port 8080 to the outside world
 EXPOSE 8080
 
 # Command to run the executable
-CMD ["./uplink-relay"]
+ENTRYPOINT ["/app/uplink-relay"]


### PR DESCRIPTION
This:

* Updates the Dockerfile to use different stages + move the using `ENTRYPOINT` to pass in arguments
* Updates the publish GH Action to run only on tags and manual invocations