### PR TITLE
Issue39: Remove wildcard * from registration of RelayHandler

### DIFF
--- a/main.go
+++ b/main.go
@@ -172,7 +172,7 @@ func startup(userConfig *config.Config, logger *slog.Logger, systemCache cache.C
 
 	proxy.DeregisterHandlers()
 	// Set up the main request handler
-	proxy.RegisterHandlers("/*", proxy.RelayHandler(userConfig, systemCache, rrSelector, httpClient, logger))
+	proxy.RegisterHandlers("/", proxy.RelayHandler(userConfig, systemCache, rrSelector, httpClient, logger))
 	proxy.RegisterHandlers("/persisted-queries/*", persistedqueries.PersistedQueryHandler(logger, httpClient, systemCache))
 	// Set up the webhook handler if enabled
 	if userConfig.Webhook.Enabled {


### PR DESCRIPTION
Probably safest to merge in https://github.com/apollosolutions/uplink-relay/pull/41 first.

------------

Fixes #39 

Using the asterisk no longer works, after a "breaking change of an undocumented feature" was introduced.

For details, read here: https://github.com/golang/go/issues/68856#issuecomment-2473628680

uplink-relay will not function at all without making this change with newer versions of go (ie: 1.22.5+)