### PR TITLE
bufix: fixing retrycount for polling configuration and adding version flag for easier debugging

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,9 +16,10 @@ builds:
     goarch:
       - amd64
       - arm64
-
+    ldflags:
+      - -X "apollosolutions/uplink-relay/version.Version={{ .Version }}"
 archives:
-  - format: tar.gz
+  - formats: tar.gz
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -30,7 +31,7 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: zip
 
 changelog:
   sort: asc

--- a/config/config.go
+++ b/config/config.go
@@ -136,6 +136,7 @@ func NewDefaultConfig() *Config {
 			PersistedQueries: &pFalse,
 			Entitlements:     &pTrue,
 			Supergraph:       &pTrue,
+			RetryCount:       1,
 		},
 		ManagementAPI: ManagementAPIConfig{
 			Enabled: false,
@@ -199,6 +200,10 @@ func MergeWithDefaultConfig(defaultConfig *Config, loadedConfig *Config, enableD
 
 	if loadedConfig.Polling.PersistedQueries == nil {
 		loadedConfig.Polling.PersistedQueries = defaultConfig.Polling.PersistedQueries
+	}
+
+	if loadedConfig.Polling.RetryCount < 1 {
+		loadedConfig.Polling.RetryCount = defaultConfig.Polling.RetryCount
 	}
 
 	if loadedConfig.ManagementAPI.Path == "" {

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ import (
 	apolloredis "apollosolutions/uplink-relay/redis"
 	"apollosolutions/uplink-relay/tiered_cache"
 	"apollosolutions/uplink-relay/uplink"
+	"apollosolutions/uplink-relay/version"
 	"apollosolutions/uplink-relay/webhooks"
 
 	"github.com/99designs/gqlgen/graphql/handler"
@@ -37,6 +38,8 @@ var (
 	configPath   = flag.String("config", "", "Path to the configuration file")
 	enableDebug  = flag.Bool("debug", false, "Enable debug logging")
 	configSchema = flag.Bool("config-schema", false, "Print the JSON schema for the configuration file")
+	// Version is the version of the application.
+	versionFlag = flag.Bool("version", false, "Print the version of the application")
 )
 
 // init parses the command-line flags.
@@ -56,6 +59,13 @@ func main() {
 		fmt.Print(jsonSchema)
 		return
 	}
+
+	// Print the version if the version flag is set.
+	if *versionFlag {
+		fmt.Println(version.BuildVersion())
+		return
+	}
+
 	// Load the default configuration.
 	defaultConfig := config.NewDefaultConfig()
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"fmt"
+)
+
+var (
+	Version = "dev"
+)
+
+func BuildVersion() string {
+	return fmt.Sprintf("%s", Version)
+}


### PR DESCRIPTION
This pull request introduces several updates to enhance versioning, configuration management, and build processes. The changes include adding a version flag to the application, improving the configuration defaults, and refining the `.goreleaser.yaml` file for better build customization.

### Versioning Enhancements:
* Added a new `version` package with a `BuildVersion` function and a `Version` variable to manage application versioning.
* Introduced a `--version` flag in `main.go` to print the application version. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R30) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R41-R42) [[3]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R62-R68)

### Configuration Improvements:
* Added a `RetryCount` field with a default value of `1` in the `Polling` configuration.
* Updated the `MergeWithDefaultConfig` function to ensure `RetryCount` is set to the default value if not specified or invalid in the loaded configuration.

### Build Process Updates:
* Updated `.goreleaser.yaml` to include `ldflags` for embedding the version into the binary and corrected the `archives` field for consistency. [[1]](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L19-R22) [[2]](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L33-R34)