### PR TITLE
fix case where cache.enabled being unset was defaulting to false

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -52,9 +52,9 @@ type UplinkConfig struct {
 
 // CacheConfig specifies the cache duration and max size.
 type CacheConfig struct {
-	Enabled  bool `yaml:"enabled" json:"enabled" jsonschema:"default=true"` // Whether in-memory caching is enabled.
-	Duration int  `yaml:"duration" json:"duration,omitempty"`               // Duration to keep in-memory cached content, in seconds.
-	MaxSize  int  `yaml:"maxSize" json:"maxSize,omitempty"`                 // Maximum size of the in-memory cache.
+	Enabled  *bool `yaml:"enabled" json:"enabled" jsonschema:"default=true"` // Whether in-memory caching is enabled.
+	Duration int   `yaml:"duration" json:"duration,omitempty"`               // Duration to keep in-memory cached content, in seconds.
+	MaxSize  int   `yaml:"maxSize" json:"maxSize,omitempty"`                 // Maximum size of the in-memory cache.
 }
 
 // RedisConfig defines the configuration for connecting to a Redis cache.
@@ -122,7 +122,7 @@ func NewDefaultConfig() *Config {
 			StudioAPIURL: "https://graphql.api.apollographql.com/api/graphql",
 		},
 		Cache: CacheConfig{
-			Enabled:  true,
+			Enabled:  &pTrue,
 			Duration: -1,
 			MaxSize:  1000,
 		},
@@ -168,6 +168,10 @@ func MergeWithDefaultConfig(defaultConfig *Config, loadedConfig *Config, enableD
 
 	if loadedConfig.Uplink.RetryCount < 1 {
 		loadedConfig.Uplink.RetryCount = defaultConfig.Uplink.RetryCount
+	}
+
+	if loadedConfig.Cache.Enabled == nil {
+		loadedConfig.Cache.Enabled = defaultConfig.Cache.Enabled
 	}
 
 	if loadedConfig.Cache.Duration == 0 {

--- a/entitlements/entitlements.go
+++ b/entitlements/entitlements.go
@@ -88,7 +88,7 @@ func FetchRouterLicense(userConfig *config.Config, systemCache cache.Cache, logg
 		return err
 	}
 
-	if userConfig.Cache.Enabled {
+	if userConfig.Cache.Enabled != nil && *userConfig.Cache.Enabled {
 		// Cache the license
 		return CacheLicense(systemCache, logger, graphRef, response.Data.RouterEntitlements.Entitlement.Jwt, expiration, userConfig.Cache.Duration, "")
 	}

--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func main() {
 	var uplinkCache cache.Cache
 	// Initialize the cache based on the configuration.
 	// We want to use the first cache that is enabled, which should be the in-memory cache
-	if mergedConfig.Cache.Enabled {
+	if mergedConfig.Cache.Enabled != nil && *mergedConfig.Cache.Enabled {
 		uplinkCaches = append(uplinkCaches, cache.NewMemoryCache(mergedConfig.Cache.MaxSize))
 	}
 	// Memory -> Filesystem -> Redis

--- a/persisted_queries/persisted_queries.go
+++ b/persisted_queries/persisted_queries.go
@@ -86,7 +86,7 @@ func PersistedQueryHandler(logger *slog.Logger, client *http.Client, systemCache
 
 func CachePersistedQueryChunkData(config *config.Config, logger *slog.Logger, systemCache cache.Cache, chunks []UplinkPersistedQueryChunk) ([]UplinkPersistedQueryChunk, error) {
 	// Validate caching is disabled, but also ignore this logic altogether if there's no public URL in the config, as it's used to advertise the cached URLs.
-	if !config.Cache.Enabled || config.Relay.PublicURL == "" {
+	if config.Cache.Enabled == nil || !*config.Cache.Enabled || config.Relay.PublicURL == "" {
 		logger.Debug("Caching disabled, skipping", "publicURL", config.Relay.PublicURL, "cacheEnabled", config.Cache.Enabled)
 		return chunks, nil
 	}
@@ -197,7 +197,7 @@ func FetchPQManifest(userConfig *config.Config, systemCache cache.Cache, logger 
 		return err
 	}
 
-	if userConfig.Cache.Enabled {
+	if userConfig.Cache.Enabled != nil && *userConfig.Cache.Enabled {
 		chunks, err := CachePersistedQueryChunkData(userConfig, logger, systemCache, response.Data.PersistedQueries.Chunks)
 		if err != nil {
 			return err

--- a/pinning/license.go
+++ b/pinning/license.go
@@ -39,7 +39,7 @@ func PinOfflineLicense(userConfig *config.Config, logger *slog.Logger, systemCac
 	modifiedTime := warnAt.AddDate(0, 0, -30)
 
 	// Store the core schema in the cache
-	if userConfig.Cache.Enabled {
+	if userConfig.Cache.Enabled != nil && *userConfig.Cache.Enabled {
 		cacheEntry := cache.CacheItem{
 			ID:           modifiedTime.Format(time.RFC3339),
 			Hash:         util.HashString(license),

--- a/pinning/persisted_queries.go
+++ b/pinning/persisted_queries.go
@@ -141,7 +141,7 @@ func PinPersistedQueries(userConfig *config.Config, logger *slog.Logger, systemC
 		return err
 	}
 
-	if userConfig.Cache.Enabled {
+	if userConfig.Cache.Enabled != nil && *userConfig.Cache.Enabled {
 		// Insert the pinned cache entry
 		chunks, err := cachePinnedChunks(userConfig, logger, systemCache, node)
 		if err != nil {

--- a/pinning/schema.go
+++ b/pinning/schema.go
@@ -144,7 +144,7 @@ func PinLaunchID(userConfig *config.Config, logger *slog.Logger, systemCache cac
 	}
 
 	// Store the core schema in the cache
-	if userConfig.Cache.Enabled {
+	if userConfig.Cache.Enabled != nil && *userConfig.Cache.Enabled {
 		cacheKey := cache.MakeCacheKey(graphRef, SupergraphPinned)
 		insertPinnedCacheEntry(logger, systemCache, cacheKey, apiResponse.Data.Graph.Variant.Launch.Build.Result.CoreSchema.CoreDocument, apiResponse.Data.Graph.Variant.ID, modifiedAt)
 	}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -202,7 +202,7 @@ func modifyProxiedResponse(config *config.Config, systemCache cache.Cache, cache
 				uplinkRequest.Variables["ifAfterId"] = ""
 			}
 			// Cache the response for future requests.
-			if config.Cache.Enabled {
+			if config.Cache.Enabled != nil && *config.Cache.Enabled {
 				logger.Debug("Caching schema", "key", cacheKey)
 				err = schema.CacheSchema(systemCache, logger, uplinkRequest.Variables["graph_ref"].(string), supergraph, id, uplinkRequest.Variables["ifAfterId"].(string), config.Cache.Duration)
 				if err != nil {
@@ -234,7 +234,7 @@ func modifyProxiedResponse(config *config.Config, systemCache cache.Cache, cache
 				return err
 			}
 			// Cache the response for future requests, if caching is enabled
-			if config.Cache.Enabled {
+			if config.Cache.Enabled != nil && *config.Cache.Enabled {
 				logger.Debug("Caching JWT", "key", cacheKey)
 				ifAfterId := ""
 				if uplinkRequest.Variables["ifAfterId"] != nil {
@@ -259,7 +259,7 @@ func modifyProxiedResponse(config *config.Config, systemCache cache.Cache, cache
 			logger.Debug("PersistedQuery response", "response", uplinkResponse)
 
 			// Cache the response for future requests, if caching is enabled
-			if config.Cache.Enabled {
+			if config.Cache.Enabled != nil && *config.Cache.Enabled {
 				logger.Debug("Caching PersistedQuery", "key", cacheKey)
 				chunks, err := persistedqueries.CachePersistedQueryChunkData(config, logger, systemCache, uplinkResponse.Data.PersistedQueries.Chunks)
 				if err != nil {
@@ -530,7 +530,7 @@ func RelayHandler(userConfig *config.Config, currentCache cache.Cache, rrSelecto
 		// Make the cache key using the graphID, variantID, and operationName
 		cacheKey := cache.MakeCacheKey(uplinkRequest.Variables["graph_ref"].(string), operationName, uplinkRequest.Variables)
 		// If cache is enabled, attempt to retrieve the response from the cache
-		if userConfig.Cache.Enabled {
+		if userConfig.Cache.Enabled != nil && *userConfig.Cache.Enabled {
 			// Check if the response is cached and return it if found
 			if cacheContent, keyFound := currentCache.Get(cacheKey); keyFound {
 				// Handle the cache hit

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -40,13 +40,14 @@ func TestRelayHandler(t *testing.T) {
 	// Create a mock cache
 	mockCache := cache.NewMemoryCache(10)
 
+	pTrue := true
 	// Create a mock config
 	mockConfig := &config.Config{
 		Uplink: config.UplinkConfig{
 			URLs: []string{mockServer.URL},
 		},
 		Cache: config.CacheConfig{
-			Enabled:  true,
+			Enabled:  &pTrue,
 			Duration: 50000,
 		},
 	}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -83,7 +83,7 @@ func FetchSchema(userConfig *config.Config, systemCache cache.Cache, logger *slo
 		logger.Error("Failed to parse license expiration", "graphRef", variables["graph_ref"], "err", err)
 		return err
 	}
-	if userConfig.Cache.Enabled {
+	if userConfig.Cache.Enabled != nil && *userConfig.Cache.Enabled {
 		// Cache the schema
 		return CacheSchema(systemCache, logger, graphRef, response.Data.RouterConfig.SupergraphSdl, id, "", userConfig.Cache.Duration)
 	}

--- a/webhooks/webhooks.go
+++ b/webhooks/webhooks.go
@@ -109,7 +109,7 @@ func WebhookHandler(userConfig *config.Config, systemCache cache.Cache, httpClie
 		// Convert the schema to a string
 		schema := string(response)
 
-		if userConfig.Cache.Enabled {
+		if userConfig.Cache.Enabled != nil && *userConfig.Cache.Enabled {
 			// Create a cache key using the GraphID, VariantID
 			cacheKey := cache.MakeCacheKey(data.VariantID, "SupergraphSdlQuery")
 			if cacheKey == "" {

--- a/webhooks/webhooks_test.go
+++ b/webhooks/webhooks_test.go
@@ -35,7 +35,7 @@ func TestWebhookHandler(t *testing.T) {
 			Secret: "secret",
 		},
 		Cache: config.CacheConfig{
-			Enabled:  true,
+			Enabled:  &truePointer,
 			MaxSize:  10,
 			Duration: -1,
 		},


### PR DESCRIPTION
Converts `cache.enabled` to a pointer to enable the value to be set to true/false since there wasn't a way prior to determine whether a user set the value; this enables a default value to true to be set. 

The other config values default to false so don't need updated at the moment. 